### PR TITLE
Add support of GitHub Enterprise

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -52,6 +52,9 @@ console.debug("selection is:", selection);
 
       // We're looking at a GitHub issue
       name = $("#show_issue .number strong").text() + " " + $("#show_issue .discussion-topic-title").text();
+      if(/^\s*$/.test(name)) {
+          name = $("#show_issue .gh-header-number").text() + " " + $("#show_issue .js-issue-title").text();
+      }
 
     } else if ($("#all_commit_comments").length) {
 


### PR DESCRIPTION
On GitHub Enterprise, card name is not properly filled.
Seems that the DOM structure is not exactly the same.
Then, if no name is set (i.e. filled with blank characters only), we try an other way to fill it.
